### PR TITLE
adding segment routing statistics support

### DIFF
--- a/junos-telemetry/sr_stats_per_if_egress.proto
+++ b/junos-telemetry/sr_stats_per_if_egress.proto
@@ -1,0 +1,48 @@
+syntax = "proto2";
+
+import "telemetry_top.proto";
+
+//
+// This occupies branch 16 from JuniperNetworksSensors
+//
+extend JuniperNetworksSensors {
+    optional SrStatsPerIfEgress jnpr_sr_stats_per_if_egress_ext = 17;
+}
+
+//
+// Top-level message
+//
+message SrStatsPerIfEgress {
+    // List of SR stats per IF egress records
+    repeated SegmentRoutingInterfaceRecord per_if_records = 1;
+}
+
+//
+// SR statistics record
+//
+message SegmentRoutingInterfaceRecord  {
+    // Interface name, e.g., xe-0/0/0
+    required string if_name = 1 [(telemetry_options).is_key = true];
+
+    // Name of parent for AE interface, if applicable
+    optional string parent_ae_name    = 2    [(telemetry_options).is_key = true];
+
+    // Name of the counter. This is useful when an interface has multiple counters.
+    // for some scenarios, it is possible that a new counter is
+    // created in the hardware.
+    optional string  counter_name         = 3  [(telemetry_options).is_key = true];
+
+    // Traffic statistics
+    optional SegmentRoutingIfStats ingress_stats = 4;
+    optional SegmentRoutingIfStats egress_stats = 5;
+}
+
+message SegmentRoutingIfStats {
+    // Packet and Byte statistics
+    optional uint64      packets = 1         [(telemetry_options).is_counter = true];
+    optional uint64      bytes = 2           [(telemetry_options).is_counter = true];
+
+    // Rates of the above counters.
+    optional uint64      packet_rate = 3    [(telemetry_options).is_gauge = true];
+    optional uint64      byte_rate = 4     [(telemetry_options).is_gauge = true];
+}

--- a/junos-telemetry/sr_stats_per_if_ingress.proto
+++ b/junos-telemetry/sr_stats_per_if_ingress.proto
@@ -1,0 +1,48 @@
+syntax = "proto2";
+
+import "telemetry_top.proto";
+
+//
+// This occupies branch 19 from JuniperNetworksSensors
+//
+extend JuniperNetworksSensors {
+    optional SrStatsPerIfIngress jnpr_sr_stats_per_if_ingress_ext = 19;
+}
+
+//
+// Top-level message
+//
+message SrStatsPerIfIngress {
+    // List of SR stats per IF ingress records
+    repeated SegmentRoutingIngIfRecord per_if_records = 1;
+}
+
+//
+// SR statistics record
+//
+message SegmentRoutingIngIfRecord  {
+    // Interface name, e.g., xe-0/0/0
+    required string if_name = 1 [(telemetry_options).is_key = true];
+
+    // Name of parent for AE interface, if applicable
+    optional string parent_ae_name    = 2    [(telemetry_options).is_key = true];
+
+    // Name of the counter. This is useful when an interface has multiple counters.
+    // for some scenarios, it is possible that a new counter is
+    // created in the hardware.
+    optional string  counter_name         = 3  [(telemetry_options).is_key = true];
+
+    // Traffic statistics
+    optional SegmentRoutingIngIfStats ingress_stats = 4;
+    optional SegmentRoutingIngIfStats egress_stats = 5;
+}
+
+message SegmentRoutingIngIfStats {
+    // Packet and Byte statistics
+    optional uint64      packets = 1         [(telemetry_options).is_counter = true];
+    optional uint64      bytes = 2           [(telemetry_options).is_counter = true];
+
+    // Rates of the above counters.
+    optional uint64      packet_rate = 3    [(telemetry_options).is_gauge = true];
+    optional uint64      byte_rate = 4     [(telemetry_options).is_gauge = true];
+}

--- a/junos-telemetry/sr_stats_per_sid.proto
+++ b/junos-telemetry/sr_stats_per_sid.proto
@@ -1,0 +1,50 @@
+syntax = "proto2";
+
+import "telemetry_top.proto";
+
+//
+// This occupies branch 16 from JuniperNetworksSensors
+//
+extend JuniperNetworksSensors {
+    optional SrStatsPerSid jnpr_sr_stats_per_sid_ext = 16;
+}
+
+//
+// Top-level message
+//
+message SrStatsPerSid {
+    // List of SR stats per SID records (ingress only as of now)
+    repeated SegmentRoutingRecord sid_stats = 1;
+}
+
+//
+// SR statistics record
+//
+message SegmentRoutingRecord {
+    // Name of the SID
+    required string      sid_identifier        = 1  [(telemetry_options).is_key = true];
+
+    // Instance Identifier for cases when RPD creates multiple instances
+    optional uint32 instance_identifier        = 2  [(telemetry_options).is_key = true];
+
+    // Name of the counter. This is useful when an SR label has multiple counters.
+    // For some scenarios like routing restart, it is possible that a new counter is
+    // created in the hardware.
+    required string      counter_name         = 3  [(telemetry_options).is_key = true];
+
+    // Ingress Traffic statistics
+    optional SegmentRoutingStats ingress_stats = 4;
+
+    // Egress statistics
+    optional SegmentRoutingStats egress_stats  = 5;
+}
+
+message SegmentRoutingStats {
+    // Packet and Byte statistics
+    optional uint64      packets = 1         [(telemetry_options).is_counter = true];
+    optional uint64      bytes = 2           [(telemetry_options).is_counter = true];
+
+    // Rates of the above counters.
+    optional uint64      packet_rate = 3    [(telemetry_options).is_gauge = true];
+    optional uint64      byte_rate = 4     [(telemetry_options).is_gauge = true];
+}

--- a/lib/sr_stats_per_if_egress.pb.rb
+++ b/lib/sr_stats_per_if_egress.pb.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'telemetry_top.pb'
+
+
+##
+# Message Classes
+#
+class SrStatsPerIfEgress < ::Protobuf::Message; end
+class SegmentRoutingInterfaceRecord < ::Protobuf::Message; end
+class SegmentRoutingIfStats < ::Protobuf::Message; end
+
+
+##
+# Message Fields
+#
+class SrStatsPerIfEgress
+  repeated ::SegmentRoutingInterfaceRecord, :per_if_records, 1
+end
+
+class SegmentRoutingInterfaceRecord
+  required :string, :if_name, 1, :".telemetry_options" => { :is_key => true }
+  optional :string, :parent_ae_name, 2, :".telemetry_options" => { :is_key => true }
+  optional :string, :counter_name, 3, :".telemetry_options" => { :is_key => true }
+  optional ::SegmentRoutingIfStats, :ingress_stats, 4
+  optional ::SegmentRoutingIfStats, :egress_stats, 5
+end
+
+class SegmentRoutingIfStats
+  optional :uint64, :packets, 1, :".telemetry_options" => { :is_counter => true }
+  optional :uint64, :bytes, 2, :".telemetry_options" => { :is_counter => true }
+  optional :uint64, :packet_rate, 3, :".telemetry_options" => { :is_gauge => true }
+  optional :uint64, :byte_rate, 4, :".telemetry_options" => { :is_gauge => true }
+end
+
+
+##
+# Extended Message Fields
+#
+class ::JuniperNetworksSensors < ::Protobuf::Message
+  optional ::SrStatsPerIfEgress, :".jnpr_sr_stats_per_if_egress_ext", 17, :extension => true
+end
+

--- a/lib/sr_stats_per_if_ingress.pb.rb
+++ b/lib/sr_stats_per_if_ingress.pb.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'telemetry_top.pb'
+
+
+##
+# Message Classes
+#
+class SrStatsPerIfIngress < ::Protobuf::Message; end
+class SegmentRoutingIngIfRecord < ::Protobuf::Message; end
+class SegmentRoutingIngIfStats < ::Protobuf::Message; end
+
+
+##
+# Message Fields
+#
+class SrStatsPerIfIngress
+  repeated ::SegmentRoutingIngIfRecord, :per_if_records, 1
+end
+
+class SegmentRoutingIngIfRecord
+  required :string, :if_name, 1, :".telemetry_options" => { :is_key => true }
+  optional :string, :parent_ae_name, 2, :".telemetry_options" => { :is_key => true }
+  optional :string, :counter_name, 3, :".telemetry_options" => { :is_key => true }
+  optional ::SegmentRoutingIngIfStats, :ingress_stats, 4
+  optional ::SegmentRoutingIngIfStats, :egress_stats, 5
+end
+
+class SegmentRoutingIngIfStats
+  optional :uint64, :packets, 1, :".telemetry_options" => { :is_counter => true }
+  optional :uint64, :bytes, 2, :".telemetry_options" => { :is_counter => true }
+  optional :uint64, :packet_rate, 3, :".telemetry_options" => { :is_gauge => true }
+  optional :uint64, :byte_rate, 4, :".telemetry_options" => { :is_gauge => true }
+end
+
+
+##
+# Extended Message Fields
+#
+class ::JuniperNetworksSensors < ::Protobuf::Message
+  optional ::SrStatsPerIfIngress, :".jnpr_sr_stats_per_if_ingress_ext", 19, :extension => true
+end
+

--- a/lib/sr_stats_per_sid.pb.rb
+++ b/lib/sr_stats_per_sid.pb.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'telemetry_top.pb'
+
+
+##
+# Message Classes
+#
+class SrStatsPerSid < ::Protobuf::Message; end
+class SegmentRoutingRecord < ::Protobuf::Message; end
+class SegmentRoutingStats < ::Protobuf::Message; end
+
+
+##
+# Message Fields
+#
+class SrStatsPerSid
+  repeated ::SegmentRoutingRecord, :sid_stats, 1
+end
+
+class SegmentRoutingRecord
+  required :string, :sid_identifier, 1, :".telemetry_options" => { :is_key => true }
+  optional :uint32, :instance_identifier, 2, :".telemetry_options" => { :is_key => true }
+  required :string, :counter_name, 3, :".telemetry_options" => { :is_key => true }
+  optional ::SegmentRoutingStats, :ingress_stats, 4
+  optional ::SegmentRoutingStats, :egress_stats, 5
+end
+
+class SegmentRoutingStats
+  optional :uint64, :packets, 1, :".telemetry_options" => { :is_counter => true }
+  optional :uint64, :bytes, 2, :".telemetry_options" => { :is_counter => true }
+  optional :uint64, :packet_rate, 3, :".telemetry_options" => { :is_gauge => true }
+  optional :uint64, :byte_rate, 4, :".telemetry_options" => { :is_gauge => true }
+end
+
+
+##
+# Extended Message Fields
+#
+class ::JuniperNetworksSensors < ::Protobuf::Message
+  optional ::SrStatsPerSid, :".jnpr_sr_stats_per_sid_ext", 16, :extension => true
+end
+


### PR DESCRIPTION
per-SID statistics will have the same counters written to DB as regular RSVP MPLS LSPs
per-Interface (ingress/egress) SR statistics will be written to DB with same counter IDs as per-Interface statistics 